### PR TITLE
Bug fixes

### DIFF
--- a/scripts/magscot_wrapper.sh
+++ b/scripts/magscot_wrapper.sh
@@ -322,7 +322,7 @@ then
 	cd $outdir
 	singularity run \
 		--bind /lustre:/lustre \
-		$LOCAL_IMAGES/magscot.sif \
+		$LOCAL_IMAGES/magscot.sif MagScoT.R \
 			-i $outdir/contig_to_bin.tsv \
 			--hmm $hmm_dir/input.hmm
 	if ! test -f $outdir/MAGScoT.refined.contig_to_bin.out || [ `head $outdir/MAGScoT.refined.contig_to_bin.out | wc -l` -eq 0 ]

--- a/scripts/map_runner.sh
+++ b/scripts/map_runner.sh
@@ -673,7 +673,7 @@ do
 			prefix_input=$prefix.$assembler.$part
 			mem=1000
 			# rm -rf $main_dir/mags/$part/complete
-			bsub -n16 -q long -R"span[hosts=1]" \
+			bsub -n16 -q oversubscribed -R"span[hosts=1]" \
 				-o $main_dir/mags/$part/logs/metagenome_assembly_pipeline.%J.o \
 				-e $main_dir/mags/$part/logs/metagenome_assembly_pipeline.%J.e \
 				-M$mem \


### PR DESCRIPTION
Changes:
- metagenome_assembly_pipeline.sh submits to oversubscribed queue rather than long, so it will not time out while waiting for basement (bin3C) jobs
- Fix MagScoT image call so it calls the executable script when running with the conda-safe container